### PR TITLE
[WORKFLOW] Introduce REST ActiveSessionEndpoint in headless timer

### DIFF
--- a/libs/rapid/common/JsonDeserializer.cpp
+++ b/libs/rapid/common/JsonDeserializer.cpp
@@ -172,4 +172,18 @@ std::optional<Common::SessionMetaData> deserialize(std::string const& rawData)
 
 } // namespace SessionMetaData
 
+namespace Track
+{
+std::optional<Common::TrackData> derserialize(std::string rawData)
+{
+    try {
+        auto json = nlohmann::ordered_json{};
+        return parseTrack(json.parse(rawData));
+    } catch (nlohmann::json::exception const& e) {
+        SPDLOG_CRITICAL("Failed to deserialize track. {}", e.what());
+        return std::nullopt;
+    }
+}
+} // namespace Track
+
 } // namespace Rapid::Common::JsonDeserializer

--- a/libs/rapid/common/JsonDeserializer.hpp
+++ b/libs/rapid/common/JsonDeserializer.hpp
@@ -22,6 +22,11 @@ namespace SessionMetaData
 std::optional<Common::SessionMetaData> deserialize(std::string const& rawData);
 }
 
+namespace Track
+{
+std::optional<Common::TrackData> derserialize(std::string rawData);
+}
+
 } // namespace Rapid::Common::JsonDeserializer
 
 #endif // JSONDESERIALIZER_HPP

--- a/libs/rapid/common/JsonSerializer.cpp
+++ b/libs/rapid/common/JsonSerializer.cpp
@@ -63,7 +63,7 @@ nlohmann::ordered_json serialize(PositionData const& position)
 namespace Track
 {
 
-nlohmann::ordered_json serialize(TrackData const& track)
+nlohmann::ordered_json serializeTrack(TrackData const& track)
 {
     auto json = nlohmann::ordered_json{};
     json["name"] = track.getTrackName();
@@ -80,6 +80,11 @@ nlohmann::ordered_json serialize(TrackData const& track)
     return json;
 }
 
+std::string serialize(TrackData const& trackData)
+{
+    return serializeTrack(trackData).dump();
+}
+
 } // namespace Track
 
 namespace Session
@@ -91,7 +96,7 @@ nlohmann::ordered_json serializeSessionMetaData(SessionMetaData const& session)
     json["id"] = session.getId();
     json["date"] = session.getSessionDate().asString();
     json["time"] = session.getSessionTime().asString();
-    json["track"] = Track::serialize(session.getTrack());
+    json["track"] = Track::serializeTrack(session.getTrack());
 
     return json;
 }

--- a/libs/rapid/common/JsonSerializer.hpp
+++ b/libs/rapid/common/JsonSerializer.hpp
@@ -7,21 +7,37 @@
 
 #include "SessionData.hpp"
 
-namespace Rapid::Common::JsonSerializer::Session
+namespace Rapid::Common::JsonSerializer
+{
+
+namespace Session
 {
 
 /**
- * Serialize the passed session meta data into a JSON string.
- * return string with JSON content.
+ * @brief Serialize the passed session meta data into a JSON string.
+ * @return string with JSON content.
  */
 std::string serialize(SessionMetaData const& sessionMetaData);
 
 /**
- * Serialize the passed session into a JSON string.
- * return string with JSON content.
+ * @brief Serialize the passed session into a JSON string.
+ * @return string with JSON content.
  */
 std::string serialize(SessionData const& session);
 
-} // namespace Rapid::Common::JsonSerializer::Session
+} // namespace Session
+
+namespace Track
+{
+
+/**
+ * @brief Serialize the passed track into a JSON string.
+ * @return string with the JSON content.
+ */
+std::string serialize(TrackData const& trackData);
+
+} // namespace Track
+
+} // namespace Rapid::Common::JsonSerializer
 
 #endif // JSONSERIALIZER_HPP

--- a/libs/rapid/rest/Path.cpp
+++ b/libs/rapid/rest/Path.cpp
@@ -94,4 +94,14 @@ bool operator!=(Path const& lhs, Path const& rhs)
     return !(lhs == rhs);
 }
 
+bool Path::operator==(char const* rhs) const noexcept
+{
+    return mData->mPath == rhs;
+}
+
+bool Path::operator!=(char const* rhs) const noexcept
+{
+    return !(*this == rhs);
+}
+
 } // namespace Rapid::Rest

--- a/libs/rapid/rest/Path.hpp
+++ b/libs/rapid/rest/Path.hpp
@@ -93,6 +93,20 @@ public:
      */
     friend bool operator!=(Path const& lhs, Path const& rhs);
 
+    /**
+     * @brief Equal operator for const char*
+     * @return true The two objects are the same.
+     * @return false The two objects are not the same.
+     */
+    bool operator==(char const* rhs) const noexcept;
+
+    /**
+     * @brief Not equal operator for const char*
+     * @return true The two objects are the same.
+     * @return false The two objects are not the same.
+     */
+    bool operator!=(char const* rhs) const noexcept;
+
 private:
     Common::SharedDataPointer<SharedPath> mData;
 };

--- a/libs/rapid/workflow/ActiveSessionEndpoint.cpp
+++ b/libs/rapid/workflow/ActiveSessionEndpoint.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2025 All contributors
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "ActiveSessionEndpoint.hpp"
+#include <common/JsonSerializer.hpp>
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+
+using namespace Rapid::Rest;
+using namespace Rapid::Common;
+
+namespace Rapid::Workflow
+{
+
+ActiveSessionEndpoint::ActiveSessionEndpoint(IActiveSessionWorkflow* activeSessionWorkflow)
+    : Rest::IRestRequestHandler()
+    , mActiveSessionWorkflow{activeSessionWorkflow}
+{
+}
+
+ActiveSessionEndpoint::~ActiveSessionEndpoint() = default;
+
+void ActiveSessionEndpoint::handleRestRequest(Rest::RestRequest& request) noexcept
+{
+    try {
+        if (not isValidPath(request.getPath())) {
+            finished.emit(RequestHandleResult::Error, request);
+        } else if (request.getPath().getEntry(1) == "track") {
+            handleTrackRequest(request);
+        } else if (request.getPath().getEntry(1) == "lap") {
+            handleLapRequest(request);
+        }
+    } catch (std::exception const& e) {
+        SPDLOG_ERROR("Failed to emit the finished signal. Error: Already emitting");
+    }
+}
+
+void ActiveSessionEndpoint::handleTrackRequest(Rest::RestRequest& request)
+{
+    auto result = RequestHandleResult::Ok;
+    auto maybeTrack = mActiveSessionWorkflow->getTrack();
+    if (maybeTrack.has_value()) {
+        auto jsonTrack = JsonSerializer::Track::serialize(maybeTrack.value());
+        request.setReturnBody(jsonTrack);
+        request.setReturnType(RequestReturnType::Json);
+    }
+    finished.emit(result, request);
+}
+
+void ActiveSessionEndpoint::handleLapRequest(Rest::RestRequest& request)
+{
+    auto json = nlohmann::ordered_json{};
+    json["lapCount"] = mActiveSessionWorkflow->lapCount.get();
+    json["currentLap"] = mActiveSessionWorkflow->currentLaptime.get().asString();
+    json["currentSector"] = mActiveSessionWorkflow->currentSectorTime.get().asString();
+    json["lastLap"] = mActiveSessionWorkflow->lastLaptime.get().asString();
+    json["lastSector"] = mActiveSessionWorkflow->lastSectorTime.get().asString();
+
+    request.setReturnBody(json.dump());
+    request.setReturnType(RequestReturnType::Json);
+    finished.emit(RequestHandleResult::Ok, request);
+}
+
+bool ActiveSessionEndpoint::isValidPath(Rest::Path const& path) const noexcept
+{
+    if (path != "/activeSession/lap" and path != "/activeSession/track") {
+        return false;
+    }
+    return true;
+}
+
+} // namespace Rapid::Workflow

--- a/libs/rapid/workflow/ActiveSessionEndpoint.hpp
+++ b/libs/rapid/workflow/ActiveSessionEndpoint.hpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2025 All contributors
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef RAPID_WORKFLOW_ACTIVESESSIONENDPOINT_HPP
+#define RAPID_WORKFLOW_ACTIVESESSIONENDPOINT_HPP
+
+#include <rest/IRestRequestHandler.hpp>
+#include <workflow/IActiveSessionWorkflow.hpp>
+
+namespace Rapid::Workflow
+{
+
+/**
+ * @brief The @ref ActiveSessionEndpoint provides the information of the current active session.
+ *
+ * @details The @ref ActiveSessionEndpoint provides two endpoints:
+ *          - /activeSession/track
+ *            Provides the used track for the session
+ *          - /activeSession/lap
+ *            Provides the current lap information
+ *            - Lap count
+ *            - Last lap time
+ *            - Last sector time
+ *            - Current lap time
+ *            - Current sector time
+ */
+class ActiveSessionEndpoint : public Rest::IRestRequestHandler
+{
+public:
+    /**
+     * @brief Creates an instance of the @ref ActiveSessionEndpoint
+     * @param activeSessionWorkflow The active session to gather the information from
+     */
+    explicit ActiveSessionEndpoint(IActiveSessionWorkflow* activeSessionWorkflow);
+
+    /**
+     * Default destructor
+     */
+    ~ActiveSessionEndpoint() override;
+
+    /**
+     * Disalbed copy constructor
+     */
+    ActiveSessionEndpoint(ActiveSessionEndpoint const&) = delete;
+
+    /**
+     * Disalbed copy operator
+     */
+    ActiveSessionEndpoint& operator=(ActiveSessionEndpoint const&) = delete;
+
+    /**
+     * Disalbed move constructor
+     */
+    ActiveSessionEndpoint(ActiveSessionEndpoint&&) noexcept = delete;
+
+    /**
+     * Disalbed move operator
+     */
+    ActiveSessionEndpoint& operator=(ActiveSessionEndpoint&&) noexcept = delete;
+
+    /**
+     * @copydoc IRestRequestHandler::handleRestRequest
+     */
+    void handleRestRequest(Rest::RestRequest& request) noexcept override;
+
+private:
+    void handleTrackRequest(Rest::RestRequest& request);
+    void handleLapRequest(Rest::RestRequest& request);
+    bool isValidPath(Rest::Path const& path) const noexcept;
+
+    IActiveSessionWorkflow* mActiveSessionWorkflow = nullptr;
+};
+
+} // namespace Rapid::Workflow
+
+#endif // !RAPID_WORKFLOW_ACTIVESESSIONENDPOINT_HPP

--- a/libs/rapid/workflow/ActiveSessionWorkflow.cpp
+++ b/libs/rapid/workflow/ActiveSessionWorkflow.cpp
@@ -29,7 +29,7 @@ void ActiveSessionWorkflow::startActiveSession() noexcept
         std::ignore =
             mLaptimer.currentSectorTime.valueChanged().connect(&ActiveSessionWorkflow::onCurrentSectorTimeChanged,
                                                                this);
-        mLaptimer.setTrack(mTrack);
+        mLaptimer.setTrack(mTrack.value_or(TrackData{}));
         std::ignore = mLaptimer.lapStarted.connect([this]() {
             mLapActive = true;
         });
@@ -41,7 +41,7 @@ void ActiveSessionWorkflow::startActiveSession() noexcept
             }
         });
         auto dateTime = mDateTimeProvider.gpsPosition.get();
-        mSession = Common::SessionData{mTrack, dateTime.getDate(), dateTime.getTime()};
+        mSession = Common::SessionData{mTrack.value_or(TrackData{}), dateTime.getDate(), dateTime.getTime()};
         lapCount.set(0);
     } catch (std::exception const& e) {
         spdlog::error("Unknow Error on starting active session. Error: {}", e.what());
@@ -61,6 +61,14 @@ void ActiveSessionWorkflow::stopActiveSession() noexcept
 void ActiveSessionWorkflow::setTrack(Common::TrackData const& track) noexcept
 {
     mTrack = track;
+}
+
+std::optional<Common::TrackData> ActiveSessionWorkflow::getTrack() const noexcept
+{
+    if (mTrack.has_value()) {
+        return mTrack;
+    }
+    return std::nullopt;
 }
 
 std::optional<Common::SessionData> ActiveSessionWorkflow::getSession() const noexcept

--- a/libs/rapid/workflow/ActiveSessionWorkflow.hpp
+++ b/libs/rapid/workflow/ActiveSessionWorkflow.hpp
@@ -41,6 +41,11 @@ public:
     void setTrack(Common::TrackData const& track) noexcept override;
 
     /**
+     * @copydoc IActiveSessionWorkflow::getTrack()
+     */
+    std::optional<Common::TrackData> getTrack() const noexcept override;
+
+    /**
      * @copydoc IActiveSessionWorkflow::getActiveSession()
      */
     std::optional<Common::SessionData> getSession() const noexcept override;
@@ -73,7 +78,7 @@ private:
     Algorithm::ILaptimer& mLaptimer;
     Storage::ISessionDatabase& mDatabase;
     std::optional<Common::SessionData> mSession;
-    Common::TrackData mTrack;
+    std::optional<Common::TrackData> mTrack;
     Common::LapData mCurrentLap;
     bool mLapActive = false;
 

--- a/libs/rapid/workflow/CMakeLists.txt
+++ b/libs/rapid/workflow/CMakeLists.txt
@@ -5,6 +5,7 @@ set(RAPID_WORKFLOW_PUBLIC_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/ActiveSessionWorkflow.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/IRestSessionManagementWorkflow.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RestSessionManagementWorkflow.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ActiveSessionEndpoint.hpp
 )
 install(FILES ${RAPID_WORKFLOW_PUBLIC_HEADERS} DESTINATION "${INCLUDE_INSTALL_DIR}/workflow")
 
@@ -14,6 +15,7 @@ PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/TrackDetectionWorkflow.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ActiveSessionWorkflow.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RestSessionManagementWorkflow.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ActiveSessionEndpoint.cpp
 )
 
 if(ENABLE_QT)

--- a/libs/rapid/workflow/IActiveSessionWorkflow.hpp
+++ b/libs/rapid/workflow/IActiveSessionWorkflow.hpp
@@ -56,6 +56,15 @@ public:
     virtual void setTrack(Common::TrackData const& track) noexcept = 0;
 
     /**
+     * @brief Gives the track that is used in the active session.
+     *
+     * @details The IActiveSessionWorkflow can only return a track when a track was set with @ref IActiveSessionWorkflow::setTrack.
+     *
+     * @return The track when set or a nullopt when no track is present.
+     */
+    virtual std::optional<Common::TrackData> getTrack() const noexcept = 0;
+
+    /**
      * Gives the currently active session.
      * Only returns a valid session if startActiveSession is called.
      * @return The currently active session.

--- a/libs/testhelper/ActiveSessionMock.hpp
+++ b/libs/testhelper/ActiveSessionMock.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025 All contributors
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef RAPID_TESTHELPER_ACTIVESESSIONMOCK_HPP
+#define RAPID_TESTHELPER_ACTIVESESSIONMOCK_HPP
+
+#include <trompeloeil.hpp>
+#include <workflow/IActiveSessionWorkflow.hpp>
+
+namespace Rapid::TestHelper
+{
+class ActiveSessionMock : public Workflow::IActiveSessionWorkflow
+{
+public:
+    MAKE_MOCK(startActiveSession, auto()->void, noexcept override);
+    MAKE_MOCK(stopActiveSession, auto()->void, noexcept override);
+    MAKE_MOCK(setTrack, auto(Common::TrackData const&)->void, noexcept override);
+    MAKE_MOCK(getTrack, auto()->std::optional<Common::TrackData>, const noexcept override);
+    MAKE_MOCK(getSession, auto()->std::optional<Common::SessionData>, const noexcept override);
+};
+
+} // namespace Rapid::TestHelper
+
+#endif // !RAPID_TESTHELPER_ACTIVESESSIONMOCK_HPP

--- a/libs/testhelper/CMakeLists.txt
+++ b/libs/testhelper/CMakeLists.txt
@@ -24,6 +24,7 @@ PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/SignalSpy.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RestClientMock.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/UbloxDevice.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ActiveSessionMock.hpp
 )
 
 target_include_directories(TestHelper

--- a/libs/testhelper/Tracks.cpp
+++ b/libs/testhelper/Tracks.cpp
@@ -73,4 +73,33 @@ Common::TrackData getTrack()
     return track;
 }
 
+std::string getTrackAsJson()
+{
+    // clang-format off
+    constexpr auto json =
+        "{"
+            "\"name\":\"Track\","
+            "\"startline\":{"
+                "\"latitude\":\"52\","
+                "\"longitude\":\"11.2\""
+            "},"
+            "\"finishline\":{"
+                "\"latitude\":\"52\","
+                "\"longitude\":\"11.2\""
+            "},"
+            "\"sectors\":["
+                "{"
+                   "\"latitude\":\"52\","
+                   "\"longitude\":\"11.2\""
+                "},"
+                "{"
+                   "\"latitude\":\"52\","
+                   "\"longitude\":\"11.2\""
+                "}"
+            "]"
+        "}";
+    // clang-format on
+    return json;
+}
+
 } // namespace Rapid::TestHelper::Tracks

--- a/libs/testhelper/Tracks.hpp
+++ b/libs/testhelper/Tracks.hpp
@@ -13,6 +13,7 @@ Common::TrackData getTrackWithoutSector();
 Common::TrackData getOscherslebenTrack();
 Common::TrackData getOscherslebenTrack2();
 Common::TrackData getTrack();
+std::string getTrackAsJson();
 } // namespace Rapid::TestHelper::Tracks
 
 #endif //! TRACKS_HPP

--- a/programs/rapid_headless/RapidHeadless.cpp
+++ b/programs/rapid_headless/RapidHeadless.cpp
@@ -32,7 +32,12 @@ LappyHeadless::LappyHeadless(Rapid::Positioning::IGpsPositionProvider& posProvid
     mTrackDetectionWorkflow.startDetection();
 
     mRestServer.registerGetHandler(std::string{"/sessions"}, &mSessionEndpoint);
-    (void)mRestServer.start();
+    mRestServer.registerGetHandler(std::string{"/activeSession"}, std::addressof(mActiveSessionEndpoint));
+    if (mRestServer.start() == Rest::ServerStartResult::Ok) {
+        SPDLOG_INFO("Succesful start REST server");
+    } else {
+        SPDLOG_ERROR("Failed to start REST server");
+    }
 }
 
 } // namespace Rapid::LappyHeadless

--- a/programs/rapid_headless/RapidHeadless.hpp
+++ b/programs/rapid_headless/RapidHeadless.hpp
@@ -11,6 +11,7 @@
 #include <rest/SessionEndpoint.hpp>
 #include <storage/ISessionDatabase.hpp>
 #include <storage/ITrackDatabase.hpp>
+#include <workflow/ActiveSessionEndpoint.hpp>
 #include <workflow/ActiveSessionWorkflow.hpp>
 #include <workflow/TrackDetectionWorkflow.hpp>
 
@@ -34,6 +35,7 @@ private:
     Rapid::Workflow::ActiveSessionWorkflow mActiveSessionWorkflow{mPositionProvider, mSimpleLaptimer, mSessionDatabase};
     Rapid::Rest::SessionEndpoint mSessionEndpoint{mSessionDatabase};
     Rapid::Rest::RestServer mRestServer;
+    Rapid::Workflow::ActiveSessionEndpoint mActiveSessionEndpoint{std::addressof(mActiveSessionWorkflow)};
 };
 
 } // namespace Rapid::LappyHeadless

--- a/tests/common/test_JsonDeserializer.cpp
+++ b/tests/common/test_JsonDeserializer.cpp
@@ -5,6 +5,7 @@
 #include "TestFile.hpp"
 #include "common/JsonDeserializer.hpp"
 #include "testhelper/Sessions.hpp"
+#include "testhelper/Tracks.hpp"
 #include <catch2/catch_all.hpp>
 #include <fstream>
 #include <iostream>
@@ -13,7 +14,7 @@
 using namespace Rapid::Common;
 using namespace Rapid::TestHelper;
 
-TEST_CASE("The JsonDeserializer shall deserialize a valid json string into a SessionData")
+TEST_CASE("The JsonDeserializer shall deserialize a valid json string into a SessionData", "[JSONDESERIALIZER_SESSION]")
 {
     auto expectedSession = Sessions::getTestSession();
     auto result = JsonDeserializer::Session::deserialize(Sessions::getTestSessionAsJson());
@@ -26,7 +27,8 @@ TEST_CASE("The JsonDeserializer shall deserialize a valid json string into a Ses
     // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
-TEST_CASE("The JsonDeserializer shall deserialize a real world json string into a SessionData")
+TEST_CASE("The JsonDeserializer shall deserialize a real world json string into a SessionData",
+          "[JSONDESERIALIZER_SESSION]")
 {
     std::ifstream file(TEST_FILE_PATH);
     REQUIRE(file.is_open());
@@ -40,7 +42,8 @@ TEST_CASE("The JsonDeserializer shall deserialize a real world json string into 
     // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
-TEST_CASE("The JsonDeserializer shall deserialize a valid json string into a SessionMetaData")
+TEST_CASE("The JsonDeserializer shall deserialize a valid json string into a SessionMetaData",
+          "[JSONDESERIALIZER_SESSION]")
 {
     auto expectedSession = Sessions::getTestSessionMetaData();
     auto result = JsonDeserializer::SessionMetaData::deserialize(Sessions::getTestSessionMetaAsJson());
@@ -50,4 +53,12 @@ TEST_CASE("The JsonDeserializer shall deserialize a valid json string into a Ses
     CHECK(result.value().getSessionTime() == expectedSession.getSessionTime());
     REQUIRE(result.value().getTrack() == expectedSession.getTrack());
     // NOLINTEND(bugprone-unchecked-optional-access)
+}
+
+TEST_CASE("The JsonDeserializer shall deserialize a valid json string into a TrackData", "[JSONDESERIALIZER_TRACK]")
+{
+    auto expTrack = Tracks::getTrack();
+    auto track = JsonDeserializer::Track::derserialize(Tracks::getTrackAsJson());
+    REQUIRE(track.has_value());
+    REQUIRE(track.value_or(TrackData{}) == expTrack);
 }

--- a/tests/common/test_JsonSerializer.cpp
+++ b/tests/common/test_JsonSerializer.cpp
@@ -2,24 +2,30 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#define CATCH_CONFIG_MAIN
-#include "common/JsonSerializer.hpp"
-#include "testhelper/Sessions.hpp"
 #include <catch2/catch_all.hpp>
+#include <common/JsonSerializer.hpp>
+#include <testhelper/Sessions.hpp>
+#include <testhelper/Tracks.hpp>
 
 using namespace Rapid::Common;
 using namespace Rapid::TestHelper;
 
-TEST_CASE("Serialize a session to a json string")
+TEST_CASE("Serialize a session to a json string", "[JSONSERIALIZER_SESSION]")
 {
     auto const session = Sessions::getTestSession();
     std::string result = JsonSerializer::Session::serialize(session);
     REQUIRE(result == Sessions::getTestSessionAsJson());
 }
 
-TEST_CASE("Serialize a sessionmetadata to a json string")
+TEST_CASE("Serialize a sessionmetadata to a json string", "[JSONSERIALIZER_SESSION]")
 {
     auto const session = Sessions::getTestSessionMetaData();
     std::string result = JsonSerializer::Session::serialize(session);
     REQUIRE(result == Sessions::getTestSessionMetaAsJson());
+}
+
+TEST_CASE("Serialize a trackdata to a json string", "[JSONSERIALIZER_TRACK]")
+{
+    auto jsonTrack = JsonSerializer::Track::serialize(Tracks::getTrack());
+    REQUIRE(jsonTrack == Tracks::getTrackAsJson());
 }

--- a/tests/rest/test_Path.cpp
+++ b/tests/rest/test_Path.cpp
@@ -135,3 +135,21 @@ SCENARIO("The Path shall return the whole path as string")
         }
     }
 }
+
+TEST_CASE("The Path shall be comparable with a strings")
+{
+    auto const path = Path{"/test/1234"};
+    SECTION("Compare with char*")
+    {
+        auto const* str = "/test/1234";
+        REQUIRE(path == str);
+        REQUIRE_FALSE(path != str);
+    }
+
+    SECTION("Compare with string")
+    {
+        auto const str = std::string{"/test/1234"};
+        REQUIRE(path == str);
+        REQUIRE_FALSE(path != str);
+    }
+}

--- a/tests/workflow/CMakeLists.txt
+++ b/tests/workflow/CMakeLists.txt
@@ -7,6 +7,7 @@ PRIVATE
     test_ActiveSessionWorkflow.cpp
     test_RestSessionManagementWorkflow.cpp
     test_TrackDetectionWorkflow.cpp
+    test_ActiveSessionEndpoint.cpp
 )
 
 target_link_libraries(test_workflow

--- a/tests/workflow/test_ActiveSessionEndpoint.cpp
+++ b/tests/workflow/test_ActiveSessionEndpoint.cpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2025 All contributors
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <catch2/catch_all.hpp>
+#include <catch2/trompeloeil.hpp>
+#include <rest/RestRequest.hpp>
+#include <testhelper/ActiveSessionMock.hpp>
+#include <testhelper/SignalSpy.hpp>
+#include <testhelper/Tracks.hpp>
+#include <workflow/ActiveSessionEndpoint.hpp>
+#include <workflow/IActiveSessionWorkflow.hpp>
+
+using namespace Rapid::Workflow;
+using namespace Rapid::Rest;
+using namespace Rapid::TestHelper;
+using namespace Rapid::Common;
+using namespace trompeloeil;
+
+namespace
+{
+
+class TestFixture
+{
+public:
+    ActiveSessionMock activeSessionMock;
+    ActiveSessionEndpoint endpoint{std::addressof(activeSessionMock)};
+    SignalSpy<RequestHandleResult, RestRequest> finishedSpy = SignalSpy{endpoint.finished};
+};
+
+} // namespace
+
+TEST_CASE_METHOD(TestFixture,
+                 "The ActiveSessionEndpoint shall provide the active session data via REST",
+                 "[ACTIVE_SESSION_ENDPOINT]")
+{
+    SECTION("Handle invalid root path")
+    {
+        auto request = RestRequest{RequestType::Get, "/asdf"};
+
+        endpoint.handleRestRequest(request);
+
+        REQUIRE(finishedSpy.getCount() == 1);
+        auto [result, response] = finishedSpy.at(0);
+        CHECK(result == RequestHandleResult::Error);
+    }
+
+    SECTION("Handle invalid sub path")
+    {
+        auto request = RestRequest{RequestType::Get, "/activeSession/asdf"};
+
+        endpoint.handleRestRequest(request);
+
+        REQUIRE(finishedSpy.getCount() == 1);
+        auto [result, response] = finishedSpy.at(0);
+        CHECK(result == RequestHandleResult::Error);
+    }
+
+    SECTION("Provide the track on \"/activeSession/track\" path")
+    {
+        auto request = RestRequest{RequestType::Get, "/activeSession/track"};
+        REQUIRE_CALL(activeSessionMock, getTrack()).LR_RETURN(Tracks::getTrack());
+
+        endpoint.handleRestRequest(request);
+
+        REQUIRE(finishedSpy.getCount() == 1);
+        auto [result, response] = finishedSpy.at(0);
+        CHECK(result == RequestHandleResult::Ok);
+        CHECK(response.getReturnType() == RequestReturnType::Json);
+        REQUIRE(response.getReturnBody() == Tracks::getTrackAsJson());
+    }
+
+    SECTION("Provide the current lap information \"/activeSession/lap\"")
+    {
+        auto request = RestRequest{RequestType::Get, "/activeSession/lap"};
+        // clang-format off
+        auto expReturnBody = std::string
+        {
+        "{"
+                "\"lapCount\":10,"
+                "\"currentLap\":\"00:01:25.123\","
+                "\"currentSector\":\"00:00:25.123\","
+                "\"lastLap\":\"00:01:25.123\","
+                "\"lastSector\":\"00:00:25.123\""
+           "}"
+        };
+        // clang-format on
+        activeSessionMock.lapCount.set(10);
+        activeSessionMock.currentLaptime.set(Timestamp{"00:01:25.123"});
+        activeSessionMock.currentSectorTime.set(Timestamp{"00:00:25.123"});
+        activeSessionMock.lastLaptime.set(Timestamp{"00:01:25.123"});
+        activeSessionMock.lastSectorTime.set(Timestamp{"00:00:25.123"});
+
+        endpoint.handleRestRequest(request);
+
+        REQUIRE(finishedSpy.getCount() == 1);
+        auto [result, response] = finishedSpy.at(0);
+        CHECK(result == RequestHandleResult::Ok);
+        CHECK(response.getReturnType() == RequestReturnType::Json);
+        REQUIRE(response.getReturnBody() == expReturnBody);
+    }
+}

--- a/tests/workflow/test_ActiveSessionWorkflow.cpp
+++ b/tests/workflow/test_ActiveSessionWorkflow.cpp
@@ -6,6 +6,7 @@
 #include "testhelper/PositionDateTimeProvider.hpp"
 #include "testhelper/Positions.hpp"
 #include "testhelper/SessionDatabaseMock.hpp"
+#include "testhelper/SignalSpy.hpp"
 #include "workflow/ActiveSessionWorkflow.hpp"
 
 using namespace Rapid::Workflow;
@@ -13,259 +14,209 @@ using namespace Rapid::TestHelper;
 using namespace Rapid::Storage;
 using namespace Rapid::Common;
 
-TEST_CASE("The ActiveSessionWorkflow shall not do return a session when start isn't called")
+class TestFixture
 {
-    auto lp = Laptimer{};
-    auto dp = PositionDateTimeProvider{};
-    auto sdb = SessionDatabaseMock{};
-    auto actSessWf = ActiveSessionWorkflow{dp, lp, sdb};
+public:
+    Laptimer lp{};
+    PositionDateTimeProvider dp{};
+    SessionDatabaseMock sdb{};
+    ActiveSessionWorkflow actSessWf{dp, lp, sdb};
+};
 
-    REQUIRE(!actSessWf.getSession());
+TEST_CASE_METHOD(TestFixture, "The ActiveSessionWorkflow shall be able to start and stop", "[ACTIVESESSION_WORKFLOW]")
+{
+    SECTION("Shall not do return a session when start isn't called")
+    {
+        REQUIRE_FALSE(actSessWf.getSession());
+    }
+
+    SECTION("Shall return a session when start called")
+    {
+        actSessWf.startActiveSession();
+        REQUIRE(actSessWf.getSession());
+    }
+
+    SECTION("The ActiveSessionWorkflow shall not return a valid session when stop is called.")
+    {
+        actSessWf.startActiveSession();
+        REQUIRE(actSessWf.getSession());
+        actSessWf.stopActiveSession();
+        REQUIRE(!actSessWf.getSession());
+    }
 }
 
-TEST_CASE("The ActiveSessionWorkflow shall return a session when start called")
+TEST_CASE_METHOD(TestFixture,
+                 "The ActiveSessionWorkflow shall session data in the database",
+                 "[ACTIVESESSION_WORKFLOW]")
 {
-    auto lp = Laptimer{};
-    auto dp = PositionDateTimeProvider{};
-    auto sdb = SessionDatabaseMock{};
-    auto actSessWf = ActiveSessionWorkflow{dp, lp, sdb};
+    SECTION("Store session data when the laptimer emits lap finished")
+    {
+        auto expectedLap = LapData{Timestamp{"00:23:13.123"}};
+        auto res = std::make_shared<Rapid::System::AsyncResult>();
+        res->setResult(Rapid::System::Result::Ok);
 
-    actSessWf.startActiveSession();
+        REQUIRE_CALL(sdb, storeSession(trompeloeil::_)).WITH(_1.getNumberOfLaps() == 1).RETURN(res);
 
-    REQUIRE(actSessWf.getSession());
+        actSessWf.startActiveSession();
+        lp.sectorTimes.emplace_back("00:23:13.123");
+        lp.lapFinished.emit();
+
+        REQUIRE(actSessWf.getSession().value_or(SessionData{}).getLaps().size() == 1);
+        REQUIRE(actSessWf.getSession().value_or(SessionData{}).getLap(0) == expectedLap);
+    }
+
+    SECTION("Store the sector times in a lap of a session")
+    {
+        auto expectedLap = LapData{{
+            Timestamp{"00:23:123.233"},
+            Timestamp{"00:23:123.233"},
+        }};
+
+        REQUIRE_CALL(sdb, storeSession(trompeloeil::_)).RETURN(std::make_shared<Rapid::System::AsyncResult>());
+
+        actSessWf.startActiveSession();
+
+        lp.sectorTimes.emplace_back("00:23:123.233");
+        lp.sectorFinished.emit();
+
+        lp.sectorTimes.emplace_back("00:23:123.233");
+        lp.lapFinished.emit();
+
+        REQUIRE(actSessWf.getSession());
+        REQUIRE(actSessWf.getSession().value_or(SessionData{}).getNumberOfLaps() == 1);
+        REQUIRE(actSessWf.getSession().value_or(SessionData{}).getLap(0) == expectedLap);
+    }
+
+    SECTION("Store every GPS position updates to the lap when the lap is started")
+    {
+        auto const expectedPos =
+            GpsPositionData{PositionData{52.1, 11.3}, Timestamp{"00:00:00.000"}, Date{"01.01.1970"}, VelocityData{100}};
+
+        ALLOW_CALL(sdb, storeSession(trompeloeil::_)).RETURN(std::make_shared<Rapid::System::AsyncResult>());
+
+        actSessWf.startActiveSession();
+        lp.lapStarted.emit();
+        dp.gpsPosition.set(expectedPos);
+        lp.lapFinished.emit();
+
+        auto const session = actSessWf.getSession();
+
+        // NOLINTBEGIN(bugprone-unchecked-optional-access)
+        REQUIRE(session->getNumberOfLaps() == 1);
+        REQUIRE(session->getLap(0)->getPositions().size() == 1);
+        REQUIRE(session->getLap(0)->getPositions().at(0) == expectedPos);
+        // NOLINTEND(bugprone-unchecked-optional-access)
+    }
 }
 
-TEST_CASE("The ActiveSessionWorkflow shall store a lap in the database when the laptimer emits lap finished")
+TEST_CASE_METHOD(TestFixture, "The ActiveSessionWorkflow shall emit finished signals", "[ACTIVESESSION_WORKFLOW]")
 {
-    auto lp = Laptimer{};
-    auto dp = PositionDateTimeProvider{};
-    auto sdb = SessionDatabaseMock{};
-    auto actSessWf = ActiveSessionWorkflow{dp, lp, sdb};
-    auto res = std::make_shared<Rapid::System::AsyncResult>();
-    res->setResult(Rapid::System::Result::Ok);
+    SECTION("Emit the lap finished signal.")
+    {
+        auto expLapTimer = std::string{"00:23:13.123"};
+        auto lapFinishedSpy = SignalSpy{actSessWf.lapFinished};
 
-    REQUIRE_CALL(sdb, storeSession(trompeloeil::_)).WITH(_1.getNumberOfLaps() == 1).RETURN(res);
+        ALLOW_CALL(sdb, storeSession(trompeloeil::_)).RETURN(std::make_shared<Rapid::System::AsyncResult>());
 
-    actSessWf.startActiveSession();
-    lp.lapFinished.emit();
+        actSessWf.startActiveSession();
+        lp.sectorTimes.emplace_back(expLapTimer);
+        lp.lapFinished.emit();
+
+        REQUIRE(lapFinishedSpy.getCount() == 1);
+    }
+
+    SECTION("Emits the sector finished signal.")
+    {
+        auto expectedSectorTime = Timestamp{"00:00:12.123"};
+        auto sectorTimeSpy = SignalSpy{actSessWf.sectorFinshed};
+
+        actSessWf.startActiveSession();
+        lp.sectorTimes.emplace_back("00:00:12.123");
+        lp.sectorFinished.emit();
+
+        REQUIRE(sectorTimeSpy.getCount() == 1);
+    }
 }
 
-TEST_CASE("The ActiveSessionWorkflow shall not return a valid session when stop is called.")
+TEST_CASE_METHOD(TestFixture, "The ActiveSessionWorkflow shall update the properties", "[ACTIVESESSION_WORKFLOW]")
 {
-    auto lp = Laptimer{};
-    auto dp = PositionDateTimeProvider{};
-    auto sdb = SessionDatabaseMock{};
-    auto actSessWf = ActiveSessionWorkflow{dp, lp, sdb};
+    SECTION("Update the round laptime property when the laptimer notifes that the lap is finished")
+    {
+        auto expectedLaptime = Timestamp{"00:00:12.123"};
 
-    actSessWf.startActiveSession();
+        ALLOW_CALL(sdb, storeSession(trompeloeil::_)).RETURN(std::make_shared<Rapid::System::AsyncResult>());
 
-    REQUIRE(actSessWf.getSession());
+        actSessWf.startActiveSession();
+        lp.sectorTimes.emplace_back("00:00:12.123");
+        lp.lapFinished.emit();
 
-    actSessWf.stopActiveSession();
+        REQUIRE(actSessWf.lastLaptime.get() == expectedLaptime);
+    }
 
-    REQUIRE(!actSessWf.getSession());
+    SECTION("Update the currentLaptime property when the laptimer update the current laptime")
+    {
+        actSessWf.startActiveSession();
+
+        lp.currentLaptime.set(Timestamp{"00:00:30.123"});
+        REQUIRE(actSessWf.currentLaptime.get() == Timestamp{"00:00:30.123"});
+
+        lp.currentLaptime.set(Timestamp{"00:00:45.123"});
+        REQUIRE(actSessWf.currentLaptime.get() == Timestamp{"00:00:45.123"});
+
+        lp.currentLaptime.set(Timestamp{"00:01:15.123"});
+        REQUIRE(actSessWf.currentLaptime.get() == Timestamp{"00:01:15.123"});
+    }
+
+    SECTION("Update the currentSectorTime property when the laptimer update the current sectorTime.")
+    {
+        actSessWf.startActiveSession();
+
+        lp.currentSectorTime.set(Timestamp{"00:00:30.123"});
+        REQUIRE(actSessWf.currentSectorTime.get() == Timestamp{"00:00:30.123"});
+
+        lp.currentSectorTime.set(Timestamp{"00:00:45.123"});
+        REQUIRE(actSessWf.currentSectorTime.get() == Timestamp{"00:00:45.123"});
+
+        lp.currentSectorTime.set(Timestamp{"00:01:15.123"});
+        REQUIRE(actSessWf.currentSectorTime.get() == Timestamp{"00:01:15.123"});
+    }
+
+    SECTION("Update the lap counter when a lap is finished.")
+    {
+        ALLOW_CALL(sdb, storeSession(trompeloeil::_)).RETURN(std::make_shared<Rapid::System::AsyncResult>());
+
+        actSessWf.startActiveSession();
+
+        REQUIRE(actSessWf.lapCount.get() == 0);
+
+        lp.sectorTimes.emplace_back("00:23:32.123");
+        lp.lapFinished.emit();
+
+        REQUIRE(actSessWf.lapCount.get() == 1);
+
+        lp.lapFinished.emit();
+        REQUIRE(actSessWf.lapCount.get() == 2);
+    }
 }
 
-TEST_CASE("The ActiveSessionWorkflow shall update the round sector time property when the laptimer notifes that sector "
-          "is finished.")
+TEST_CASE_METHOD(TestFixture,
+                 "The ActiveSessionWorkflow shall forward GPS position updates",
+                 "[ACTIVESESSION_WORKFLOW]")
 {
-    auto lp = Laptimer{};
-    auto dp = PositionDateTimeProvider{};
-    auto sdb = SessionDatabaseMock{};
-    auto actSessWf = ActiveSessionWorkflow{dp, lp, sdb};
-    auto expectedSectorTime = Timestamp{"00:00:12.123"};
-    bool sectorFinishedEmitted = false;
+    SECTION("Forward all GPS position updates to the laptimer when session is active")
+    {
+        actSessWf.startActiveSession();
+        dp.gpsPosition.set(GpsPositionData{Positions::getOscherslebenPositionStartFinishLine(), {}, {}});
 
-    std::ignore = actSessWf.sectorFinshed.connect([&sectorFinishedEmitted]() {
-        sectorFinishedEmitted = true;
-    });
-    actSessWf.startActiveSession();
-    lp.sectorTimes.emplace_back("00:00:12.123");
-    lp.sectorFinished.emit();
+        REQUIRE(lp.lastPostionDateTime == GpsPositionData{Positions::getOscherslebenPositionStartFinishLine(), {}, {}});
+    }
 
-    REQUIRE(actSessWf.lastSectorTime.get() == expectedSectorTime);
-    REQUIRE(sectorFinishedEmitted == true);
-}
+    SECTION("Forward all PositionTimeDate updates to the laptimer when session is stopped")
+    {
+        actSessWf.startActiveSession();
+        actSessWf.stopActiveSession();
+        dp.gpsPosition.set(GpsPositionData{Positions::getOscherslebenPositionStartFinishLine(), {}, {}});
 
-TEST_CASE("The ActiveSessionWorkflow shall store the laptime when finished.")
-{
-    auto lp = Laptimer{};
-    auto dp = PositionDateTimeProvider{};
-    auto sdb = SessionDatabaseMock{};
-    auto actSessWf = ActiveSessionWorkflow{dp, lp, sdb};
-    auto expectedLap = LapData{Timestamp{"00:23:13.123"}};
-    bool lapFinishedEmitted = false;
-
-    ALLOW_CALL(sdb, storeSession(trompeloeil::_)).RETURN(std::make_shared<Rapid::System::AsyncResult>());
-
-    actSessWf.startActiveSession();
-    std::ignore = std::ignore = actSessWf.lapFinished.connect([&lapFinishedEmitted]() {
-        lapFinishedEmitted = true;
-    });
-    lp.sectorTimes.emplace_back("00:23:13.123");
-    lp.lapFinished.emit();
-
-    REQUIRE(actSessWf.getSession().value_or(SessionData{}).getLaps().size() == 1);
-    REQUIRE(actSessWf.getSession().value_or(SessionData{}).getLap(0) == expectedLap);
-    REQUIRE(lapFinishedEmitted == true);
-}
-
-TEST_CASE("The ActiveSessionWorkflow shall update the round laptime property when the laptimer notifes that the "
-          "is finished.")
-{
-    auto lp = Laptimer{};
-    auto dp = PositionDateTimeProvider{};
-    auto sdb = SessionDatabaseMock{};
-    auto actSessWf = ActiveSessionWorkflow{dp, lp, sdb};
-    auto expectedLaptime = Timestamp{"00:00:12.123"};
-
-    ALLOW_CALL(sdb, storeSession(trompeloeil::_)).RETURN(std::make_shared<Rapid::System::AsyncResult>());
-
-    actSessWf.startActiveSession();
-    lp.sectorTimes.emplace_back("00:00:12.123");
-    lp.lapFinished.emit();
-
-    REQUIRE(actSessWf.lastLaptime.get() == expectedLaptime);
-}
-
-TEST_CASE(
-    "The ActiveSessionWorkflow shall update the currentLaptime property when the laptimer update the current laptime.")
-{
-    auto lp = Laptimer{};
-    auto dp = PositionDateTimeProvider{};
-    auto sdb = SessionDatabaseMock{};
-    auto actSessWf = ActiveSessionWorkflow{dp, lp, sdb};
-
-    actSessWf.startActiveSession();
-
-    lp.currentLaptime.set(Timestamp{"00:00:30.123"});
-    REQUIRE(actSessWf.currentLaptime.get() == Timestamp{"00:00:30.123"});
-
-    lp.currentLaptime.set(Timestamp{"00:00:45.123"});
-    REQUIRE(actSessWf.currentLaptime.get() == Timestamp{"00:00:45.123"});
-
-    lp.currentLaptime.set(Timestamp{"00:01:15.123"});
-    REQUIRE(actSessWf.currentLaptime.get() == Timestamp{"00:01:15.123"});
-}
-
-TEST_CASE("The ActiveSessionWorkflow shall update the currentSectorTime property when the laptimer update the current "
-          "sectorTime.")
-{
-    auto lp = Laptimer{};
-    auto dp = PositionDateTimeProvider{};
-    auto sdb = SessionDatabaseMock{};
-    auto actSessWf = ActiveSessionWorkflow{dp, lp, sdb};
-
-    actSessWf.startActiveSession();
-
-    lp.currentSectorTime.set(Timestamp{"00:00:30.123"});
-    REQUIRE(actSessWf.currentSectorTime.get() == Timestamp{"00:00:30.123"});
-
-    lp.currentSectorTime.set(Timestamp{"00:00:45.123"});
-    REQUIRE(actSessWf.currentSectorTime.get() == Timestamp{"00:00:45.123"});
-
-    lp.currentSectorTime.set(Timestamp{"00:01:15.123"});
-    REQUIRE(actSessWf.currentSectorTime.get() == Timestamp{"00:01:15.123"});
-}
-
-TEST_CASE("The ActiveSessionWorkflow shall store the sector times in a lap of a session")
-{
-    auto lp = Laptimer{};
-    auto dp = PositionDateTimeProvider{};
-    auto sdb = SessionDatabaseMock{};
-    auto actSessWf = ActiveSessionWorkflow{dp, lp, sdb};
-    auto expectedLap = LapData{{
-        Timestamp{"00:23:123.233"},
-        Timestamp{"00:23:123.233"},
-    }};
-
-    ALLOW_CALL(sdb, storeSession(trompeloeil::_)).RETURN(std::make_shared<Rapid::System::AsyncResult>());
-
-    actSessWf.startActiveSession();
-
-    lp.sectorTimes.emplace_back("00:23:123.233");
-    lp.sectorFinished.emit();
-
-    lp.sectorTimes.emplace_back("00:23:123.233");
-    lp.lapFinished.emit();
-
-    REQUIRE(actSessWf.getSession());
-    REQUIRE(actSessWf.getSession().value_or(SessionData{}).getNumberOfLaps() == 1);
-    REQUIRE(actSessWf.getSession().value_or(SessionData{}).getLap(0) == expectedLap);
-}
-
-TEST_CASE("The ActiveSessionWorkflow shall update the lap counter when a lap is finished.")
-{
-    auto lp = Laptimer{};
-    auto dp = PositionDateTimeProvider{};
-    auto sdb = SessionDatabaseMock{};
-    auto actSessWf = ActiveSessionWorkflow{dp, lp, sdb};
-
-    ALLOW_CALL(sdb, storeSession(trompeloeil::_)).RETURN(std::make_shared<Rapid::System::AsyncResult>());
-
-    actSessWf.startActiveSession();
-
-    REQUIRE(actSessWf.lapCount.get() == 0);
-
-    lp.sectorTimes.emplace_back("00:23:32.123");
-    lp.lapFinished.emit();
-
-    REQUIRE(actSessWf.lapCount.get() == 1);
-
-    lp.lapFinished.emit();
-    REQUIRE(actSessWf.lapCount.get() == 2);
-}
-
-TEST_CASE("The ActiveSessionWorkflow shall forward all PositionTimeDate Updates to the laptimer when session is active")
-{
-    auto lp = Laptimer{};
-    auto dp = PositionDateTimeProvider{};
-    auto sdb = SessionDatabaseMock{};
-    auto actSessWf = ActiveSessionWorkflow{dp, lp, sdb};
-
-    actSessWf.startActiveSession();
-    dp.gpsPosition.set(GpsPositionData{Positions::getOscherslebenPositionStartFinishLine(), {}, {}});
-
-    REQUIRE(lp.lastPostionDateTime == GpsPositionData{Positions::getOscherslebenPositionStartFinishLine(), {}, {}});
-}
-
-TEST_CASE("The ActiveSessionWorkflow shall not forward all PositionTimeDate updates to the laptimer when session is "
-          "stopped")
-{
-    auto lp = Laptimer{};
-    auto dp = PositionDateTimeProvider{};
-    auto sdb = SessionDatabaseMock{};
-    auto actSessWf = ActiveSessionWorkflow{dp, lp, sdb};
-
-    actSessWf.startActiveSession();
-    actSessWf.stopActiveSession();
-    dp.gpsPosition.set(GpsPositionData{Positions::getOscherslebenPositionStartFinishLine(), {}, {}});
-
-    REQUIRE(lp.lastPostionDateTime == GpsPositionData{{}, {}, {}});
-}
-
-TEST_CASE("The ActiveSessionWorkflow shall store every GPS position updates to the lap when the lap is started")
-{
-
-    auto lp = Laptimer{};
-    auto dp = PositionDateTimeProvider{};
-    auto sdb = SessionDatabaseMock{};
-    auto actSessWf = ActiveSessionWorkflow{dp, lp, sdb};
-    auto const expectedPos =
-        GpsPositionData{PositionData{52.1, 11.3}, Timestamp{"00:00:00.000"}, Date{"01.01.1970"}, VelocityData{100}};
-
-    ALLOW_CALL(sdb, storeSession(trompeloeil::_)).RETURN(std::make_shared<Rapid::System::AsyncResult>());
-
-    actSessWf.startActiveSession();
-    lp.lapStarted.emit();
-    dp.gpsPosition.set(expectedPos);
-    lp.lapFinished.emit();
-
-    auto const session = actSessWf.getSession();
-
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
-    REQUIRE(session->getNumberOfLaps() == 1);
-    REQUIRE(session->getLap(0)->getPositions().size() == 1);
-    REQUIRE(session->getLap(0)->getPositions().at(0) == expectedPos);
-    // NOLINTEND(bugprone-unchecked-optional-access)
+        REQUIRE(lp.lastPostionDateTime == GpsPositionData{{}, {}, {}});
+    }
 }


### PR DESCRIPTION
- **workflow: Use test fixture in active session workflow**
- **workflow: Add getter in ActiveSessionWorkflow for the track**
- **common: Extend JSON serializer/deserializer for track data**
- **testhelper: Add IActiveSessionWorkflow mock**
- **rest: Allow Path to compare with const char* and std::string**
- **workflow: Introduce REST endpoint to retrieve active session information**
- **programs: Integrate ActiveSessionEndpoint in rapid_headless**
